### PR TITLE
Use explicit wsgi entry point

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -w 4 -k gthread -b 0.0.0.0:$PORT app:app
+web: gunicorn -w 4 -k gthread -b 0.0.0.0:$PORT wsgi:app

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Vite + React single-page app served by Flask for hosting on Azure App 
 
 - Build static assets with `pnpm build` (outputs to `dist/`).
 - Flask serves files from `dist/` and handles SPA fallback.
-- Azure starts the app via the `Procfile` (Gunicorn).
+- Azure starts the app via the `Procfile` (Gunicorn) using the `wsgi:app` entry point.
 
 Local run (optional):
 1. Build: `pnpm install && pnpm build`

--- a/startup.txt
+++ b/startup.txt
@@ -1,1 +1,1 @@
-gunicorn -w 4 -k gthread -b 0.0.0.0:$PORT app:app
+gunicorn -w 4 -k gthread -b 0.0.0.0:$PORT wsgi:app


### PR DESCRIPTION
## Summary
- route gunicorn through wsgi:app so deployments use the correct entry point
- document wsgi entry in README

## Testing
- `pnpm lint` *(fails: '__dirname' is not defined, react-refresh warnings)*
- `python -m py_compile app.py wsgi.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb5a41a56c832f9b2d0925fc623450