### PR TITLE
Fix web app deployment by building frontend and configuring Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-
+web: gunicorn --bind=0.0.0.0 --workers=4 wsgi:application


### PR DESCRIPTION
The web application was not browsing correctly because the frontend assets were not being built and the Procfile was empty, preventing the web server from starting.

This commit fixes the issue by:
1. Building the frontend application to generate the `dist` directory.
2. Adding the `gunicorn` command to the `Procfile` to start the web server.