### PR TITLE
build front-end assets before starting server

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --bind=0.0.0.0 --workers=4 wsgi:application
+web: sh -c 'set -e; if [ ! -d dist ]; then npm run build; fi; gunicorn --bind=0.0.0.0 --workers=4 wsgi:application'


### PR DESCRIPTION
## Summary
- build the React front-end automatically on startup so Flask can serve the app

## Testing
- `npm run build`
- `sh -c 'set -e; if [ ! -d dist ]; then npm run build; fi; gunicorn --bind=0.0.0.0:8000 --workers=1 wsgi:application'`
- `curl -I http://localhost:8000/`


------
https://chatgpt.com/codex/tasks/task_e_68bb64674354832f87617476ed69f985