### PR TITLE
Sanitize public portfolio repository metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The account owner reviews all public-source changes.
+* @AngelGoddTech

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/README.md
+++ b/README.md
@@ -1,69 +1,36 @@
-# angelgoddsantana.me — Personal Portfolio Website
+# Angel Godd Santana — Career Portfolio
 
-> Vite + React 19 + TailwindCSS 4 SPA served by Flask on Azure App Service (Linux, Python 3.13)
+[angelgoddsantana.me](https://angelgoddsantana.me)
 
-## 🏗️ Architecture
+Recruiter-first portfolio and résumé site for Angel Godd Santana, Principal Cloud & AI Platform Architect.
 
-| Component | Detail |
-|-----------|--------|
-| **Frontend** | React 19, TailwindCSS 4, Framer Motion, Three.js (lazy) |
-| **Backend** | Flask 3.0.3 → Gunicorn (serves `dist/` with SPA fallback) |
-| **Hosting** | Azure App Service — **Basic B1** (Linux, East US 2) |
-| **App Name** | `angelgoddsantana-me-v2` |
-| **Subscription** | `deb5fa03-e79e-4b80-a59f-77a3f93abd9d` (Microsoft Partner Network-2021-HoA) |
-| **Tenant** | `a486452d-40ff-4507-8b8f-4a7668c81006` |
-| **Resource Group** | `angelgoddsantana-me-rg` |
-| **Custom Domain** | [angelgoddsantana.me](https://angelgoddsantana.me) |
-| **SSL** | Azure Managed Certificate (auto-renewing) |
-| **DNS** | Azure DNS zone in `dns-4angelgoddsantana-me-rg` (sub `deb5fa03`, NS: `ns*-09`) |
-| **CI/CD** | GitHub Actions → OIDC → Azure (`deploy-azure-webapp.yml`) |
-| **Domain Registrar** | GoDaddy (expires 2027-09-04) |
+## Purpose
 
-## 💰 Monthly Cost
+This repository contains the source for the public career site. It presents selected architecture evidence, redacted reference work, and a downloadable résumé for U.S.-remote Principal Cloud Architect, AI Platform Architect, Cloud Governance, and Cloud/DevSecOps opportunities.
 
-| Service | Cost |
-|---------|-----:|
-| App Service B1 Linux | $12.41 |
-| Azure DNS (1 zone) | $0.50 |
-| GoDaddy .me domain | $2.33 |
-| GitHub/SSL/LFS | $0.00 |
-| **Total** | **$15.24** |
+## What this demonstrates
 
-## 🛠️ Local Development
+- A React and Vite frontend served as a Flask single-page application
+- Clear résumé access, recruiter-focused positioning, and consulting conversion paths
+- Accessible architecture-evidence pages for cloud governance, cross-cloud identity, and secure AI platform design
+- A deliberate public boundary between redacted reference material and private client, employer, or production systems
+
+## Local development
 
 ```bash
-# Install & build
-npm install --legacy-peer-deps  # or: npx -y pnpm install
-npm run build                    # or: npx -y pnpm run build
-
-# Run Flask dev server
-python app.py  # → http://localhost:8000
+pnpm install
+pnpm build
+python app.py
 ```
 
-## 🚀 Deployment
+## Deployment
 
-Code deploys to Azure via GitHub Actions on push to `main`:
-1. Checkout → Python venv → pip install → Upload artifact
-2. Azure OIDC login → Deploy to App Service
+Changes merged to `main` are built and deployed through GitHub Actions. Runtime infrastructure and operational configuration are intentionally kept private.
 
-**Manual deploy (if needed):**
-```bash
-# Build locally, then zip deploy
-npm run build
-zip -r deploy.zip app.py wsgi.py Procfile requirements.txt dist/
-az webapp deploy --name angelgoddsantana-me-v2 \
-  --resource-group angelgoddsantana-me-rg \
-  --subscription deb5fa03-e79e-4b80-a59f-77a3f93abd9d \
-  --src-path deploy.zip --type zip
-```
+## Public-repository boundary
 
-## 📋 Infrastructure Changelog
+This repository does not publish customer data, production configurations, tenant or subscription identifiers, credentials, or deployment logs. Architecture examples are intentionally redacted and presented as reference material rather than client delivery evidence.
 
-| Date | Change | Impact |
-|------|--------|--------|
-| 2026-05-14 | **B2 → B1 downgrade** | -$12.41/mo (-45%) |
-| 2026-05-14 | **Migrated to sub `deb5fa03`** | Cross-tenant recreate (from `19a6d236`) |
-| 2026-05-14 | App renamed `angelgoddsantana-me-v2` | Soft-delete name conflict |
-| 2026-05-14 | **OIDC CI/CD reconfigured** | New App Registration + federated credential |
-| 2026-05-14 | **DNS zone migrated to target sub** | Recreated in `deb5fa03`, GoDaddy NS updated |
-| 2026-05-14 | **SSL cert bound** | GeoTrust managed cert (auto-renewing, expires 2026-11-14) |
+## Security
+
+See [SECURITY.md](SECURITY.md) for the reporting guidance and public-repository boundary.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Scope
+
+This policy covers the public source code and deployment workflow for `angelgoddsantana.me`.
+
+## Reporting a vulnerability
+
+Please do not include credentials, tenant information, customer data, or exploit details in a public issue. Use the contact route at [angelgoddsantana.me/contact](https://angelgoddsantana.me/contact) and include `Security report` in the subject line.
+
+## Public-repository boundary
+
+This repository must not contain:
+
+- credentials, tokens, certificates, connection strings, or environment files
+- tenant, subscription, resource, principal, customer, or employer identifiers
+- production exports, deployment logs, state files, or screenshots containing operational metadata
+- client or employer source code, configurations, or artifacts
+
+Public architecture material is redacted reference work. It is not a production deployment guide or a substitute for a security review.


### PR DESCRIPTION
## Purpose
Prepare `angelgoddsantana-me` to become a credible public showcase repository without exposing unnecessary operational infrastructure context.

## Changes
- replace the README with recruiter-facing, public-safe documentation
- remove Azure subscription, tenant, resource, DNS, registrar, and manual-targeting details
- add public-repository security-reporting guidance
- add CODEOWNERS and Dependabot configuration

## Intentionally deferred
- license choice
- SHA-pinning existing Actions
- profile metadata, topics, and pins
- any change to the private Lighthouse or current chatbot repositories

No website runtime code, résumé content, credentials, or Azure configuration is changed.